### PR TITLE
Fix add-to-cart fetch headers

### DIFF
--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -1,11 +1,16 @@
 
 // Utilitaire pour fetch (similaire à Dawn)
 function fetchConfig(type = 'json') {
-    return {
+    const config = {
         method: 'POST',
-        headers: { 'Accept': 'application/json' },
-        ...(type === 'json' ? { headers: { 'Content-Type': 'application/json' } } : {})
+        headers: { 'Accept': 'application/json' }
     };
+
+    if (type === 'json') {
+        config.headers['Content-Type'] = 'application/json';
+    }
+
+    return config;
 }
 
 if (!customElements.get('product-form')) {


### PR DESCRIPTION
## Summary
- fix `fetchConfig` header merging so both Accept and Content-Type are preserved when needed

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx shopify theme check` *(failed to run due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684177814874832f9b9ddeca098269c6